### PR TITLE
Fixed Clip on transport start, re-added meters

### DIFF
--- a/loudener.jsfx
+++ b/loudener.jsfx
@@ -10,7 +10,7 @@
 // WITH DOING SO.
 
 // Thanks to: Edoardo "TheEdoRan" Ranghieri & "tviler"
-// (C) 2021, Samuele Pizzi
+// 2021, Samuele Pizzi
 
 desc:Loudener
 
@@ -31,8 +31,6 @@ in_pin:Left Input
 in_pin:Right Input
 out_pin:Left Output
 out_pin:Right Output
-
-options:no_meter
 
 filename:0,loudener_gfx/bg.png
 filename:1,loudener_gfx/handle.png
@@ -77,6 +75,7 @@ slider5 = min(max(slider5, -12),0);
 //assigning values to gui sliders
 s1.value = slider1;
 s2.value = slider2;
+s3.checked = slider3;
 s4.value = slider4;
 s5.value = slider5;
 //process slider values in plugin parameters
@@ -116,7 +115,7 @@ last_gain += d_gain;
 olast_gain += od_gain;
 
 @gfx 640 420
-gfx_x = gfx_Y = 0;
+gfx_x = gfx_y = 0;
 gfx_blit(0,1,0);
 
 function draw_slider(x,y,w,h,f,t,s,d,unit,title) (
@@ -201,12 +200,6 @@ function draw_checkbox(x,y,w,h) (
     this.checked = 1-this.checked;
     this.hasEntered = this.hasClicked = this.canChange = 0;
   );
-
-  //frame
-  //gfx_r = gfx_g = gfx_b = 0.35;
-  //gfx_rect(x,y,w,h);
-  //gfx_r = gfx_g = gfx_b = 0.07;
-  //gfx_rect(x+1,y+1,w-2,h-2);
   
   //checked
   this.checked ? (
@@ -232,4 +225,3 @@ _sliderDirty ? (
   process_sliders();  
   _sliderDirty = 0;
 );
-


### PR DESCRIPTION
Most relevant:
+ Clip 0 dB would reset on transport start or on Reaper window minimize. Issue was in "@slider" section
+ Re-added meters on the side, they are useful

Less relevant:
- Minor code cleanup
- Removed Copyright (C) symbol